### PR TITLE
Fix bug where 'undefined' directory created when no arguments provided

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ async function main() {
 
   let args = yargsParser(process.argv.slice(2))
 
-  const target = String(args._[0]) || '.'
+  const target = (args._[0] && String(args._[0])) || '.'
   const templateArg = args.template
 
   const templateDirs = await viaContentsApi(config)


### PR DESCRIPTION
This fixes a regression I introduced last week while working on adding a `--template` argument.

With `0.2.0` running with no args like `npm create hono@latest` will create an `undefined` directory instead of prompting `Directory not empty. Continue?`. The root cause is that it was casting to a String before defaulting to the current directory `.`

This patch fixes that bug.