### PR TITLE
fix(dependencies): handle --no-install flag properly

### DIFF
--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -30,7 +30,13 @@ const registerInstallationHook = (
 
     if (installArg) {
       installDeps = true
-    } else {
+    } 
+
+		if (installArg === false) {
+			installDeps = false
+    }
+
+		if (installArg === undefined) {
       installDeps = await confirm({
         message: 'Do you want to install project dependencies?',
         default: true,

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -28,15 +28,9 @@ const registerInstallationHook = (
   projectDependenciesHook.addHook(template, async ({ directoryPath }) => {
     let installDeps = false
 
-    if (installArg) {
-      installDeps = true
-    } 
-
-    if (installArg === false) {
-      installDeps = false
-    }
-
-    if (installArg === undefined) {
+    if (typeof installArg === 'boolean') {
+      installDeps = installArg
+    } else {
       installDeps = await confirm({
         message: 'Do you want to install project dependencies?',
         default: true,

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -32,11 +32,11 @@ const registerInstallationHook = (
       installDeps = true
     } 
 
-		if (installArg === false) {
-			installDeps = false
+    if (installArg === false) {
+      installDeps = false
     }
 
-		if (installArg === undefined) {
+    if (installArg === undefined) {
       installDeps = await confirm({
         message: 'Do you want to install project dependencies?',
         default: true,


### PR DESCRIPTION
This allows to run this command and skip all prompts. Useful when called from a script.

```bash
pnpm create hono my-app --template x-basic --no-install --pm pnpm
```