### PR TITLE
feat(dependencies): show only installed package managers in choices

### DIFF
--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -3,6 +3,7 @@ import { chdir, exit } from 'process'
 import confirm from '@inquirer/confirm'
 import select from '@inquirer/select'
 import chalk from 'chalk'
+import { execa } from 'execa'
 import { createSpinner } from 'nanospinner'
 import { projectDependenciesHook } from '../hook'
 
@@ -102,13 +103,9 @@ function getCurrentPackageManager(): PackageManager {
 
 function checkPackageManagerInstalled(packageManager: string) {
   return new Promise<boolean>((resolve) => {
-    exec(`${packageManager} --version`, (error) => {
-      if (error) {
-        resolve(false)
-      } else {
-        resolve(true)
-      }
-    })
+    execa(packageManager, ['--version'])
+      .then(() => resolve(true))
+      .catch(() => resolve(false))
   })
 }
 

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -109,4 +109,4 @@ function checkPackageManagerInstalled(packageManager: string) {
   })
 }
 
-export { registerInstallationHook }
+export { registerInstallationHook, checkPackageManagerInstalled }


### PR DESCRIPTION
Check if the package manager is installed by running its command with `--version`, and only show installed package managers in choices.