### PR TITLE
feat(dependencies): hide install option if no package manager is installed.

### DIFF
--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -39,7 +39,7 @@ const registerInstallationHook = (
     )
 
     // hide install dependencies option if no package manager is installed
-    if (installedPackageManagerNames.length) return
+    if (!installedPackageManagerNames.length) return
 
     if (typeof installArg === 'boolean') {
       installDeps = installArg

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -32,6 +32,21 @@ const registerInstallationHook = (
   projectDependenciesHook.addHook(template, async ({ directoryPath }) => {
     let installDeps = false
 
+    const installedPackageManagerNames = await Promise.all(
+      knownPackageManagerNames.map(checkPackageManagerInstalled),
+    ).then((results) =>
+      knownPackageManagerNames.filter((_, index) => results[index]),
+    )
+
+    // show error message if no package manager is installed
+    if (!installedPackageManagerNames.length) {
+      console.log(
+        chalk.red('×'),
+        'No package manager found. Please install one any try again.',
+      )
+      return exit(1)
+    }
+
     if (typeof installArg === 'boolean') {
       installDeps = installArg
     } else {
@@ -42,12 +57,6 @@ const registerInstallationHook = (
     }
 
     if (!installDeps) return
-
-    const installedPackageManagerNames = await Promise.all(
-      knownPackageManagerNames.map(checkPackageManagerInstalled),
-    ).then((results) =>
-      knownPackageManagerNames.filter((_, index) => results[index]),
-    )
 
     let packageManager
 

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -38,14 +38,8 @@ const registerInstallationHook = (
       knownPackageManagerNames.filter((_, index) => results[index]),
     )
 
-    // show error message if no package manager is installed
-    if (!installedPackageManagerNames.length) {
-      console.log(
-        chalk.red('×'),
-        'No package manager found. Please install one any try again.',
-      )
-      return exit(1)
-    }
+    // hide install dependencies option if no package manager is installed
+    if (installedPackageManagerNames.length) return
 
     if (typeof installArg === 'boolean') {
       installDeps = installArg


### PR DESCRIPTION
Hide the install dependencies option if no package manager is installed.
I have tested it manually and it works fine.

Thanks to @ryuapp for pointing out this issue!
Closes #45 