### PR TITLE
perf: Reduce build size

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -10,6 +10,7 @@ const b = () =>
     platform: 'node',
     outfile: 'bin',
     format: 'cjs',
+    minify: true,
   })
 
 Promise.all([b()])


### PR DESCRIPTION
This PR will reduce the build size and the time it takes to run `create-hono`.
## Changes
- https://github.com/goisaki/create-hono/pull/49/commits/78d5a5a22e0f5c0e52f3650abd61ac771ad1fa9b - Enable the `minify` option in esbuild
  - 742 KB -> 350 KB