### PR TITLE
fix: don't minify binary file

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -10,7 +10,8 @@ const b = () =>
     platform: 'node',
     outfile: 'bin',
     format: 'cjs',
-    minify: true,
+    // For debug
+    minify: false,
   })
 
 Promise.all([b()])


### PR DESCRIPTION
In #49, it changed to building with minifier, but as a result debugging became difficult.
It is better not to minify due to reports from users.

![image](https://github.com/honojs/create-hono/assets/114303361/099fdca3-d6a4-4bd0-9a93-736fdb49e53a)
