### PR TITLE
feat(workers): set compatibility date to current date

### DIFF
--- a/src/hooks/after-create.test.ts
+++ b/src/hooks/after-create.test.ts
@@ -9,6 +9,7 @@ describe('afterCreateHook', () => {
         vi.mock('fs', () => {
           const wrangler = `
 name = "%%PROJECT_NAME%%"
+compatibility_date = "2023-12-01"
 
 [env.staging]
 name = "%%PROJECT_NAME%%-staging"
@@ -24,18 +25,32 @@ name = "%%PROJECT_NAME%%-staging"
         const projectName = 'test-projectNAME+123'
         const directoryPath = './tmp'
         const wranglerPath = join(directoryPath, 'wrangler.toml')
-        const replaced = `
+
+        const firstHookContent = `
 name = "test-projectname-123"
+compatibility_date = "2023-12-01"
 
 [env.staging]
 name = "test-projectname-123-staging"
     `.trim()
+
+        // Get current date in YYYY-MM-DD format
+        const currentDate = new Date().toISOString().split('T')[0]
+        const secondHookContent = `
+name = "%%PROJECT_NAME%%"
+compatibility_date = "${currentDate}"
+
+[env.staging]
+name = "%%PROJECT_NAME%%-staging"
+    `.trim()
+
         afterCreateHook.applyHook('cloudflare-workers', {
           projectName,
           directoryPath,
         })
         expect(readFileSync).toHaveBeenCalledWith(wranglerPath, 'utf-8')
-        expect(writeFileSync).toHaveBeenCalledWith(wranglerPath, replaced)
+        expect(writeFileSync).nthCalledWith(1, wranglerPath, firstHookContent)
+        expect(writeFileSync).nthCalledWith(2, wranglerPath, secondHookContent)
       })
     })
   })

--- a/src/hooks/after-create.ts
+++ b/src/hooks/after-create.ts
@@ -17,14 +17,14 @@ afterCreateHook.addHook(
   },
 )
 
-const compatibilityDateRegex = /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/
+const COMPATIBILITY_DATE = /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/
 afterCreateHook.addHook(['cloudflare-workers'], ({ directoryPath }) => {
   const wranglerPath = path.join(directoryPath, 'wrangler.toml')
   const wrangler = readFileSync(wranglerPath, 'utf-8')
   // Get current date in YYYY-MM-DD format
   const currentDate = new Date().toISOString().split('T')[0]
   const rewritten = wrangler.replace(
-    compatibilityDateRegex,
+    COMPATIBILITY_DATE,
     `compatibility_date = "${currentDate}"`,
   )
   writeFileSync(wranglerPath, rewritten)

--- a/src/hooks/after-create.ts
+++ b/src/hooks/after-create.ts
@@ -17,4 +17,19 @@ afterCreateHook.addHook(
   },
 )
 
+const regex = /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/
+afterCreateHook.addHook(['cloudflare-workers'], ({ directoryPath }) => {
+  const wranglerPath = path.join(directoryPath, 'wrangler.toml')
+  const wrangler = readFileSync(wranglerPath, 'utf-8')
+
+  const currentDate = new Date().toISOString().split('T')[0] // Get current date in YYYY-MM-DD format
+
+  const rewritten = wrangler.replace(
+    regex,
+    `compatibility_date = "${currentDate}"`,
+  )
+
+  writeFileSync(wranglerPath, rewritten)
+})
+
 export { afterCreateHook }

--- a/src/hooks/after-create.ts
+++ b/src/hooks/after-create.ts
@@ -17,18 +17,16 @@ afterCreateHook.addHook(
   },
 )
 
-const regex = /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/
+const compatibilityDateRegex = /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/
 afterCreateHook.addHook(['cloudflare-workers'], ({ directoryPath }) => {
   const wranglerPath = path.join(directoryPath, 'wrangler.toml')
   const wrangler = readFileSync(wranglerPath, 'utf-8')
-
-  const currentDate = new Date().toISOString().split('T')[0] // Get current date in YYYY-MM-DD format
-
+  // Get current date in YYYY-MM-DD format
+  const currentDate = new Date().toISOString().split('T')[0]
   const rewritten = wrangler.replace(
-    regex,
+    compatibilityDateRegex,
     `compatibility_date = "${currentDate}"`,
   )
-
   writeFileSync(wranglerPath, rewritten)
 })
 


### PR DESCRIPTION
Closes #58 

Updates the `compatibility_date` in the Workers `wrangler.toml` file to the current date.