### PR TITLE
feat: switched from yargs-parser to commander

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^18.11.18",
     "@types/yargs-parser": "^21.0.0",
     "chalk": "^5.3.0",
+    "commander": "^12.1.0",
     "esbuild": "^0.16.17",
     "eslint": "^8.55.0",
     "execa": "^8.0.1",
@@ -43,7 +44,6 @@
     "prettier": "^3.3.3",
     "tsx": "^4.7.1",
     "typescript": "^5.3.3",
-    "vitest": "^0.34.6",
-    "yargs-parser": "^21.1.1"
+    "vitest": "^0.34.6"
   }
 }

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -16,7 +16,7 @@ const knownPackageManagers: { [key: string]: string } = {
   yarn: 'yarn',
 }
 
-const knownPackageManagerNames = Object.keys(knownPackageManagers)
+export const knownPackageManagerNames = Object.keys(knownPackageManagers)
 const currentPackageManager = getCurrentPackageManager()
 
 // Deno and Netlify need no dependency installation step

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ program
   .version(version)
   .arguments('[target]')
   .addOption(
-    new Option('-y, --install', 'Install dependencies').argParser(Boolean),
+    new Option('-i, --install', 'Install dependencies').argParser(Boolean),
   )
   .addOption(
     new Option('-p, --pm <pm>', 'Package manager to use').choices(
@@ -67,7 +67,7 @@ program
     ),
   )
   .addOption(
-    new Option('--offline', 'Use offline mode')
+    new Option('-o, --offline', 'Use offline mode')
       .argParser(Boolean)
       .default(false),
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,6 +1363,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4901,11 +4906,6 @@ yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
-yargs-parser@^21.1.1:
-  version "21.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
-  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
- [x] Removed `yargs-parser`
- [x] Added `commander`
- [x] `commander` enables the new `-h` option, describing all the options
- [x] Added a new option for using offline/cached templates