### PR TITLE
feat: confirm all questions before init repo

### DIFF
--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -23,7 +23,7 @@ const currentPackageManager = getCurrentPackageManager()
 // Deno and Netlify need no dependency installation step
 const excludeTemplate = ['deno', 'netlify']
 
-export type EventMap = { dependencies: any[]; completed: any[] }
+export type EventMap = { dependencies: unknown[]; completed: unknown[] }
 
 const registerInstallationHook = (
   template: string,


### PR DESCRIPTION
Closes #36 

- [x] I have used `EventEmitter` to detect the events, this keeps the changes to a minimum.

There are 2 events that matter - 
1. Template download complete
2. Dependencies installed

Whenever an event is completed `.emit()` function is called and the `.on()` event handler takes it from there.

