### PR TITLE
fix: projectName for "./" target

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ async function main(
   }
 
   let projectName = ''
-  if (target === '.') {
+  if (['.', './'].includes(target)) {
     projectName = path.basename(process.cwd())
   } else {
     projectName = path.basename(target)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   registerInstallationHook,
 } from './hooks/dependencies'
 
+const isCurrentDirRegex = /^(\.\/|\.\\|\.)$/
 const directoryName = 'templates'
 const config = {
   directory: directoryName,
@@ -106,7 +107,7 @@ async function main(
   }
 
   let projectName = ''
-  if (['.', './'].includes(target)) {
+  if (isCurrentDirRegex.test(target)) {
     projectName = path.basename(process.cwd())
   } else {
     projectName = path.basename(target)


### PR DESCRIPTION
This small PR fixes minor issue for creating project where as Target directory "./" is provided.

### Actual behaviour
project name in package.json is set to "." after providing "./" as Target directory:
![image](https://github.com/user-attachments/assets/979b6e41-3077-457d-ab98-bba21344586a)

### After fix
after my fix project name in package.json is properly set to current directory name:
![image](https://github.com/user-attachments/assets/7c1c03cd-495d-4ca5-93ee-3ded74c147ec)
