### PR TITLE
feat: support for `deno install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install dependencies after cloning template.
 npm create hono@latest ./my-app -- --install
 ```
 
-### `-p, --pm <pnpm|bun|npm|yarn>`
+### `-p, --pm <pnpm|bun|deno|npm|yarn>`
 
 Allows you to specify which package manager to use.
 

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -8,11 +8,12 @@ import { execa } from 'execa'
 import { createSpinner } from 'nanospinner'
 import { projectDependenciesHook } from '../hook'
 
-type PackageManager = 'npm' | 'bun' | 'pnpm' | 'yarn'
+type PackageManager = 'npm' | 'bun' | 'deno' | 'pnpm' | 'yarn'
 
 const knownPackageManagers: { [key: string]: string } = {
   npm: 'npm install',
   bun: 'bun install',
+  deno: 'deno install',
   pnpm: 'pnpm install',
   yarn: 'yarn',
 }
@@ -44,6 +45,16 @@ const registerInstallationHook = (
 
     // hide install dependencies option if no package manager is installed
     if (!installedPackageManagerNames.length) return
+    // If Deno is installed, it will not be displayed because there is no 'deno install' in version 1.
+    if (installedPackageManagerNames.includes('deno')) {
+      const { stdout } = await execa('deno', ['-v'])
+      if (stdout.split(' ')[1].split('.')[0] == '1') {
+        installedPackageManagerNames.splice(
+          installedPackageManagerNames.indexOf('deno'),
+          1,
+        )
+      }
+    }
 
     if (typeof installArg === 'boolean') {
       installDeps = installArg

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -117,6 +117,7 @@ function getCurrentPackageManager(): PackageManager {
   const agent = process.env.npm_config_user_agent || 'npm' // Types say it might be undefined, just being cautious;
 
   if (agent.startsWith('bun')) return 'bun'
+  if (agent.startsWith('deno')) return 'deno'
   if (agent.startsWith('pnpm')) return 'pnpm'
   if (agent.startsWith('yarn')) return 'yarn'
 

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -45,7 +45,7 @@ const registerInstallationHook = (
 
     // hide install dependencies option if no package manager is installed
     if (!installedPackageManagerNames.length) return
-    // If Deno is installed, it will not be displayed because there is no 'deno install' in version 1.
+    // If version 1 of Deno is installed, it will not be suggested because it doesn't have "deno install".
     if (installedPackageManagerNames.includes('deno')) {
       const { stdout } = await execa('deno', ['-v'])
       if (stdout.split(' ')[1].split('.')[0] == '1') {


### PR DESCRIPTION
Related: #73 

![image](https://github.com/user-attachments/assets/9e36bd21-26cd-4c09-9615-45ee293da336)

As shown in the issue below, Deno has npm compatibility but it does not work locally, so no tests are currently being added.
https://github.com/denoland/deno/issues/15624