### PR TITLE
fix: old deno gives an error when using `deno -v`

### DIFF
--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -49,7 +49,7 @@ const registerInstallationHook = (
     if (installedPackageManagerNames.includes('deno')) {
       let isVersion1 = false
       try {
-        const { stdout } = await execa('deno', ['-V'])
+        const { stdout } = await execa('deno', ['-v'])
         isVersion1 = stdout.split(' ')[1].split('.')[0] == '1'
       } catch {
         isVersion1 = true

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -47,8 +47,14 @@ const registerInstallationHook = (
     if (!installedPackageManagerNames.length) return
     // If version 1 of Deno is installed, it will not be suggested because it doesn't have "deno install".
     if (installedPackageManagerNames.includes('deno')) {
-      const { stdout } = await execa('deno', ['-v'])
-      if (stdout.split(' ')[1].split('.')[0] == '1') {
+      let isVersion1 = false
+      try {
+        const { stdout } = await execa('deno', ['-V'])
+        isVersion1 = stdout.split(' ')[1].split('.')[0] == '1'
+      } catch {
+        isVersion1 = true
+      }
+      if (isVersion1) {
         installedPackageManagerNames.splice(
           installedPackageManagerNames.indexOf('deno'),
           1,


### PR DESCRIPTION
Fix https://github.com/honojs/hono/issues/3503

I’m sorry. Old Deno cannot check the version with -`v`, causing errors for some users.
This PR fixes to ~~check the version with `-V` and`~~ not terminate the command if an error occurs.


Ref: https://github.com/denoland/deno/issues/5289#issuecomment-2150513464