### PR TITLE
fix: :bug: ensure process exits after copying project files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,7 @@ async function main(
   emitter.on('completed', () => {
     console.log(chalk.green(`🎉 ${chalk.bold('Copied project files')}`))
     console.log(chalk.gray('Get started with:'), chalk.bold(`cd ${target}`))
+    process.exit(0)
   })
 }
 


### PR DESCRIPTION
- :bug: Added `process.exit(0)` to cleanly terminate the Node.js process once project files are copied.
- :white_check_mark: Prevents hanging processes after file operations are complete.