### PR TITLE
fix: resolved npm_execpath issue

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -37,6 +37,7 @@ export class Hook<HookFunction extends HookSignature> {
 type AfterHookOptions = {
   projectName: string
   directoryPath: string
+  packageManager: string
 }
 
 type AfterHookFunction = (options: AfterHookOptions) => void

--- a/src/hooks/after-create.test.ts
+++ b/src/hooks/after-create.test.ts
@@ -25,6 +25,7 @@ name = "%%PROJECT_NAME%%-staging"
         const projectName = 'test-projectNAME+123'
         const directoryPath = './tmp'
         const wranglerPath = join(directoryPath, 'wrangler.toml')
+        const packageManager = 'npm'
 
         const firstHookContent = `
 name = "test-projectname-123"
@@ -47,6 +48,7 @@ name = "%%PROJECT_NAME%%-staging"
         afterCreateHook.applyHook('cloudflare-workers', {
           projectName,
           directoryPath,
+          packageManager,
         })
         expect(readFileSync).toHaveBeenCalledWith(wranglerPath, 'utf-8')
         expect(writeFileSync).nthCalledWith(1, wranglerPath, firstHookContent)

--- a/src/hooks/after-create.test.ts
+++ b/src/hooks/after-create.test.ts
@@ -52,7 +52,7 @@ name = "%%PROJECT_NAME%%-staging"
         })
         expect(readFileSync).toHaveBeenCalledWith(wranglerPath, 'utf-8')
         expect(writeFileSync).nthCalledWith(1, wranglerPath, firstHookContent)
-        expect(writeFileSync).nthCalledWith(2, wranglerPath, secondHookContent)
+        expect(writeFileSync).nthCalledWith(3, wranglerPath, secondHookContent)
       })
     })
   })

--- a/src/hooks/after-create.test.ts
+++ b/src/hooks/after-create.test.ts
@@ -52,7 +52,7 @@ name = "%%PROJECT_NAME%%-staging"
         })
         expect(readFileSync).toHaveBeenCalledWith(wranglerPath, 'utf-8')
         expect(writeFileSync).nthCalledWith(1, wranglerPath, firstHookContent)
-        expect(writeFileSync).nthCalledWith(3, wranglerPath, secondHookContent)
+        expect(writeFileSync).nthCalledWith(2, wranglerPath, secondHookContent)
       })
     })
   })

--- a/src/hooks/after-create.ts
+++ b/src/hooks/after-create.ts
@@ -3,31 +3,29 @@ import * as path from 'node:path'
 import { afterCreateHook } from '../hook'
 
 const PROJECT_NAME = new RegExp(/%%PROJECT_NAME.*%%/g)
-const PACKAGE_MANAGER = new RegExp(/\$npm_execpath/g)
 
 afterCreateHook.addHook(
   ['cloudflare-workers', 'cloudflare-pages', 'x-basic'],
-  ({ projectName, packageManager, directoryPath }) => {
-    // Read the wrangler.toml file
+  ({ projectName, directoryPath }) => {
     const wranglerPath = path.join(directoryPath, 'wrangler.toml')
     const wrangler = readFileSync(wranglerPath, 'utf-8')
     const convertProjectName = projectName
       .toLowerCase()
       .replaceAll(/[^a-z0-9\-_]/gm, '-')
-    const rewrittenWranglerFile = wrangler.replaceAll(
-      PROJECT_NAME,
-      convertProjectName,
-    )
-    writeFileSync(wranglerPath, rewrittenWranglerFile)
+    const rewritten = wrangler.replaceAll(PROJECT_NAME, convertProjectName)
+    writeFileSync(wranglerPath, rewritten)
+  },
+)
 
-    // Read the package.json file
+const PACKAGE_MANAGER = new RegExp(/\$npm_execpath/g)
+
+afterCreateHook.addHook(
+  ['cloudflare-pages', 'x-basic'],
+  ({ packageManager, directoryPath }) => {
     const packageJsonPath = path.join(directoryPath, 'package.json')
     const packageJson = readFileSync(packageJsonPath, 'utf-8')
-    const rewrittenPackageJsonFile = packageJson.replaceAll(
-      PACKAGE_MANAGER,
-      packageManager,
-    )
-    writeFileSync(packageJsonPath, rewrittenPackageJsonFile)
+    const rewritten = packageJson.replaceAll(PACKAGE_MANAGER, packageManager)
+    writeFileSync(packageJsonPath, rewritten)
   },
 )
 

--- a/src/hooks/after-create.ts
+++ b/src/hooks/after-create.ts
@@ -3,17 +3,31 @@ import * as path from 'node:path'
 import { afterCreateHook } from '../hook'
 
 const PROJECT_NAME = new RegExp(/%%PROJECT_NAME.*%%/g)
+const PACKAGE_MANAGER = new RegExp(/\$npm_execpath/g)
 
 afterCreateHook.addHook(
   ['cloudflare-workers', 'cloudflare-pages', 'x-basic'],
-  ({ projectName, directoryPath }) => {
+  ({ projectName, packageManager, directoryPath }) => {
+    // Read the wrangler.toml file
     const wranglerPath = path.join(directoryPath, 'wrangler.toml')
     const wrangler = readFileSync(wranglerPath, 'utf-8')
     const convertProjectName = projectName
       .toLowerCase()
       .replaceAll(/[^a-z0-9\-_]/gm, '-')
-    const rewritten = wrangler.replaceAll(PROJECT_NAME, convertProjectName)
-    writeFileSync(wranglerPath, rewritten)
+    const rewrittenWranglerFile = wrangler.replaceAll(
+      PROJECT_NAME,
+      convertProjectName,
+    )
+    writeFileSync(wranglerPath, rewrittenWranglerFile)
+
+    // Read the package.json file
+    const packageJsonPath = path.join(directoryPath, 'package.json')
+    const packageJson = readFileSync(packageJsonPath, 'utf-8')
+    const rewrittenPackageJsonFile = packageJson.replaceAll(
+      PACKAGE_MANAGER,
+      packageManager,
+    )
+    writeFileSync(packageJsonPath, rewrittenPackageJsonFile)
   },
 )
 

--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -24,7 +24,11 @@ const currentPackageManager = getCurrentPackageManager()
 // Deno and Netlify need no dependency installation step
 const excludeTemplate = ['deno', 'netlify']
 
-export type EventMap = { dependencies: unknown[]; completed: unknown[] }
+export type EventMap = {
+  dependencies: unknown[]
+  packageManager: unknown[]
+  completed: unknown[]
+}
 
 const registerInstallationHook = (
   template: string,
@@ -50,7 +54,7 @@ const registerInstallationHook = (
       let isVersion1 = false
       try {
         const { stdout } = await execa('deno', ['-v'])
-        isVersion1 = stdout.split(' ')[1].split('.')[0] == '1'
+        isVersion1 = stdout.split(' ')[1].split('.')[0] === '1'
       } catch {
         isVersion1 = true
       }
@@ -87,6 +91,8 @@ const registerInstallationHook = (
         default: currentPackageManager,
       })
     }
+
+    emitter.emit('packageManager', packageManager)
 
     emitter.on('dependencies', async () => {
       chdir(directoryPath)

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,12 @@ async function main(
 
   const emitter = new EventEmitter<EventMap>()
 
+  // Default package manager
+  let packageManager = 'npm'
+  emitter.addListener('packageManager', (pm) => {
+    packageManager = String(pm)
+  })
+
   registerInstallationHook(templateName, install, pm, emitter)
 
   try {
@@ -169,14 +175,15 @@ async function main(
         offline,
         force: true,
       },
-    ).then(() => {
-      spinner.success()
-      emitter.emit('dependencies')
-    })
+    )
+
+    spinner.success()
+    emitter.emit('dependencies')
 
     afterCreateHook.applyHook(templateName, {
       projectName,
       directoryPath: targetDirectoryPath,
+      packageManager,
     })
   } catch (e) {
     throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ async function main(
   const emitter = new EventEmitter<EventMap>()
 
   // Default package manager
-  let packageManager = 'npm'
+  let packageManager = pm ?? 'npm'
   emitter.addListener('packageManager', (pm) => {
     packageManager = String(pm)
   })


### PR DESCRIPTION
Closes #52 

- [x] Used event listener for the package manager.
- [x] Updated the hooks function to replace the `$npm_execpath` in `package.json` file.
- [x] Added `===` (triple equal sign) instead of `==` (double equal sign).

If the users haven't said _yes_ to installation, we may not be able to get the package manager. For that, I have made `npm` the default value.