### PR TITLE
feat: updated hooks to handle new wrangler file formats

### DIFF
--- a/src/hooks/after-create.test.ts
+++ b/src/hooks/after-create.test.ts
@@ -52,7 +52,7 @@ name = "%%PROJECT_NAME%%-staging"
         })
         expect(readFileSync).toHaveBeenCalledWith(wranglerPath, 'utf-8')
         expect(writeFileSync).nthCalledWith(1, wranglerPath, firstHookContent)
-        expect(writeFileSync).nthCalledWith(2, wranglerPath, secondHookContent)
+        expect(writeFileSync).nthCalledWith(4, wranglerPath, secondHookContent)
       })
     })
   })

--- a/src/hooks/after-create.ts
+++ b/src/hooks/after-create.ts
@@ -10,13 +10,15 @@ afterCreateHook.addHook(
   ['cloudflare-workers', 'cloudflare-pages', 'x-basic'],
   ({ projectName, directoryPath }) => {
     for (const filename in WRANGLER_FILES) {
-      const wranglerPath = path.join(directoryPath, filename)
-      const wrangler = readFileSync(wranglerPath, 'utf-8')
-      const convertProjectName = projectName
-        .toLowerCase()
-        .replaceAll(/[^a-z0-9\-_]/gm, '-')
-      const rewritten = wrangler.replaceAll(PROJECT_NAME, convertProjectName)
-      writeFileSync(wranglerPath, rewritten)
+      try {
+        const wranglerPath = path.join(directoryPath, filename)
+        const wrangler = readFileSync(wranglerPath, 'utf-8')
+        const convertProjectName = projectName
+          .toLowerCase()
+          .replaceAll(/[^a-z0-9\-_]/gm, '-')
+        const rewritten = wrangler.replaceAll(PROJECT_NAME, convertProjectName)
+        writeFileSync(wranglerPath, rewritten)
+      } catch {}
     }
   },
 )
@@ -38,15 +40,17 @@ afterCreateHook.addHook(
   ['cloudflare-workers', 'cloudflare-pages'],
   ({ directoryPath }) => {
     for (const filename in WRANGLER_FILES) {
-      const wranglerPath = path.join(directoryPath, filename)
-      const wrangler = readFileSync(wranglerPath, 'utf-8')
-      // Get current date in YYYY-MM-DD format
-      const currentDate = new Date().toISOString().split('T')[0]
-      const rewritten = wrangler.replace(
-        COMPATIBILITY_DATE,
-        `compatibility_date = "${currentDate}"`,
-      )
-      writeFileSync(wranglerPath, rewritten)
+      try {
+        const wranglerPath = path.join(directoryPath, filename)
+        const wrangler = readFileSync(wranglerPath, 'utf-8')
+        // Get current date in YYYY-MM-DD format
+        const currentDate = new Date().toISOString().split('T')[0]
+        const rewritten = wrangler.replace(
+          COMPATIBILITY_DATE,
+          `compatibility_date = "${currentDate}"`,
+        )
+        writeFileSync(wranglerPath, rewritten)
+      } catch {}
     }
   },
 )

--- a/src/hooks/after-create.ts
+++ b/src/hooks/after-create.ts
@@ -9,7 +9,7 @@ const WRANGLER_FILES = ['wrangler.toml', 'wrangler.json', 'wrangler.jsonc']
 afterCreateHook.addHook(
   ['cloudflare-workers', 'cloudflare-pages', 'x-basic'],
   ({ projectName, directoryPath }) => {
-    for (const filename in WRANGLER_FILES) {
+    for (const filename of WRANGLER_FILES) {
       try {
         const wranglerPath = path.join(directoryPath, filename)
         const wrangler = readFileSync(wranglerPath, 'utf-8')
@@ -39,7 +39,7 @@ const COMPATIBILITY_DATE = /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/
 afterCreateHook.addHook(
   ['cloudflare-workers', 'cloudflare-pages'],
   ({ directoryPath }) => {
-    for (const filename in WRANGLER_FILES) {
+    for (const filename of WRANGLER_FILES) {
       try {
         const wranglerPath = path.join(directoryPath, filename)
         const wrangler = readFileSync(wranglerPath, 'utf-8')

--- a/src/hooks/after-create.ts
+++ b/src/hooks/after-create.ts
@@ -4,16 +4,20 @@ import { afterCreateHook } from '../hook'
 
 const PROJECT_NAME = new RegExp(/%%PROJECT_NAME.*%%/g)
 
+const WRANGLER_FILES = ['wrangler.toml', 'wrangler.json', 'wrangler.jsonc']
+
 afterCreateHook.addHook(
   ['cloudflare-workers', 'cloudflare-pages', 'x-basic'],
   ({ projectName, directoryPath }) => {
-    const wranglerPath = path.join(directoryPath, 'wrangler.toml')
-    const wrangler = readFileSync(wranglerPath, 'utf-8')
-    const convertProjectName = projectName
-      .toLowerCase()
-      .replaceAll(/[^a-z0-9\-_]/gm, '-')
-    const rewritten = wrangler.replaceAll(PROJECT_NAME, convertProjectName)
-    writeFileSync(wranglerPath, rewritten)
+    for (const filename in WRANGLER_FILES) {
+      const wranglerPath = path.join(directoryPath, filename)
+      const wrangler = readFileSync(wranglerPath, 'utf-8')
+      const convertProjectName = projectName
+        .toLowerCase()
+        .replaceAll(/[^a-z0-9\-_]/gm, '-')
+      const rewritten = wrangler.replaceAll(PROJECT_NAME, convertProjectName)
+      writeFileSync(wranglerPath, rewritten)
+    }
   },
 )
 
@@ -33,15 +37,17 @@ const COMPATIBILITY_DATE = /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/
 afterCreateHook.addHook(
   ['cloudflare-workers', 'cloudflare-pages'],
   ({ directoryPath }) => {
-    const wranglerPath = path.join(directoryPath, 'wrangler.toml')
-    const wrangler = readFileSync(wranglerPath, 'utf-8')
-    // Get current date in YYYY-MM-DD format
-    const currentDate = new Date().toISOString().split('T')[0]
-    const rewritten = wrangler.replace(
-      COMPATIBILITY_DATE,
-      `compatibility_date = "${currentDate}"`,
-    )
-    writeFileSync(wranglerPath, rewritten)
+    for (const filename in WRANGLER_FILES) {
+      const wranglerPath = path.join(directoryPath, filename)
+      const wrangler = readFileSync(wranglerPath, 'utf-8')
+      // Get current date in YYYY-MM-DD format
+      const currentDate = new Date().toISOString().split('T')[0]
+      const rewritten = wrangler.replace(
+        COMPATIBILITY_DATE,
+        `compatibility_date = "${currentDate}"`,
+      )
+      writeFileSync(wranglerPath, rewritten)
+    }
   },
 )
 


### PR DESCRIPTION
- [x] It loops over all the possible filenames based on the docs - https://developers.cloudflare.com/workers/wrangler/configuration/
  - `.json`
  - `.jsonc`
  - `.toml`
- [x] Placed a try-catch to handle the error, if the file is not found