### PR TITLE
fix: replace `compatibility_date` for `wrangler.json`

### DIFF
--- a/src/hooks/after-create.test.ts
+++ b/src/hooks/after-create.test.ts
@@ -4,29 +4,42 @@ import { afterCreateHook } from './after-create'
 
 describe('afterCreateHook', () => {
   describe('cloudflare-workers', () => {
-    describe('rewriteWranglerHook', () => {
-      it('rewrites the wrangler.toml file with the project name', async () => {
-        vi.mock('fs', () => {
-          const wrangler = `
+    describe('rewriteWranglerHook', async () => {
+      vi.mock('fs', () => {
+        const directoryPath = './tmp'
+        const mockFiles: Record<string, string> = {
+          [join(directoryPath, 'wrangler.toml')]: `
 name = "%%PROJECT_NAME%%"
 compatibility_date = "2023-12-01"
 
 [env.staging]
-name = "%%PROJECT_NAME%%-staging"
-      `.trim()
+name = "%%PROJECT_NAME%%-staging"`.trim(),
+          [join(directoryPath, 'wrangler.json')]: `
+"name": "%%PROJECT_NAME%%",
+"compatibility_date": "2023-12-01",
+"env": {
+  "staging": {
+  "name": "%%PROJECT_NAME%%-staging"
+}`.trim(),
+        }
 
-          return {
-            readFileSync: vi.fn().mockReturnValue(wrangler),
-            writeFileSync: vi.fn(),
-          }
-        })
-        const { readFileSync, writeFileSync } = await import('node:fs')
+        return {
+          readFileSync: vi.fn((path: string) => {
+            if (mockFiles[path]) {
+              return mockFiles[path]
+            }
+          }),
+          writeFileSync: vi.fn(),
+        }
+      })
 
-        const projectName = 'test-projectNAME+123'
-        const directoryPath = './tmp'
-        const wranglerPath = join(directoryPath, 'wrangler.toml')
-        const packageManager = 'npm'
+      const { readFileSync, writeFileSync } = await import('node:fs')
 
+      const projectName = 'test-projectNAME+123'
+      const directoryPath = './tmp'
+      const packageManager = 'npm'
+
+      it('rewrites the wrangler.toml file with the project name', async () => {
         const firstHookContent = `
 name = "test-projectname-123"
 compatibility_date = "2023-12-01"
@@ -45,13 +58,47 @@ compatibility_date = "${currentDate}"
 name = "%%PROJECT_NAME%%-staging"
     `.trim()
 
+        const wranglerPath = join(directoryPath, 'wrangler.toml')
+
         afterCreateHook.applyHook('cloudflare-workers', {
           projectName,
           directoryPath,
           packageManager,
         })
         expect(readFileSync).toHaveBeenCalledWith(wranglerPath, 'utf-8')
+
         expect(writeFileSync).nthCalledWith(1, wranglerPath, firstHookContent)
+        expect(writeFileSync).nthCalledWith(3, wranglerPath, secondHookContent)
+      })
+
+      it('rewrites the wrangler.json file with the project name', async () => {
+        const firstHookContent = `
+"name": "test-projectname-123",
+"compatibility_date": "2023-12-01",
+"env": {
+  "staging": {
+  "name": "test-projectname-123-staging"
+}`.trim()
+
+        // Get current date in YYYY-MM-DD format
+        const currentDate = new Date().toISOString().split('T')[0]
+        const secondHookContent = `
+"name": "%%PROJECT_NAME%%",
+"compatibility_date": "${currentDate}",
+"env": {
+  "staging": {
+  "name": "%%PROJECT_NAME%%-staging"
+}`.trim()
+
+        const wranglerPath = join(directoryPath, 'wrangler.json')
+
+        afterCreateHook.applyHook('cloudflare-workers', {
+          projectName,
+          directoryPath,
+          packageManager,
+        })
+        expect(readFileSync).toHaveBeenCalledWith(wranglerPath, 'utf-8')
+        expect(writeFileSync).nthCalledWith(2, wranglerPath, firstHookContent)
         expect(writeFileSync).nthCalledWith(4, wranglerPath, secondHookContent)
       })
     })

--- a/src/hooks/after-create.ts
+++ b/src/hooks/after-create.ts
@@ -35,7 +35,8 @@ afterCreateHook.addHook(
   },
 )
 
-const COMPATIBILITY_DATE = /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/
+const COMPATIBILITY_DATE_TOML = /compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/
+const COMPATIBILITY_DATE_JSON = /"compatibility_date"\s*:\s*"\d{4}-\d{2}-\d{2}"/
 afterCreateHook.addHook(
   ['cloudflare-workers', 'cloudflare-pages'],
   ({ directoryPath }) => {
@@ -45,10 +46,15 @@ afterCreateHook.addHook(
         const wrangler = readFileSync(wranglerPath, 'utf-8')
         // Get current date in YYYY-MM-DD format
         const currentDate = new Date().toISOString().split('T')[0]
-        const rewritten = wrangler.replace(
-          COMPATIBILITY_DATE,
-          `compatibility_date = "${currentDate}"`,
-        )
+        const rewritten = wrangler
+          .replace(
+            COMPATIBILITY_DATE_TOML,
+            `compatibility_date = "${currentDate}"`,
+          )
+          .replace(
+            COMPATIBILITY_DATE_JSON,
+            `"compatibility_date": "${currentDate}"`,
+          )
         writeFileSync(wranglerPath, rewritten)
       } catch {}
     }


### PR DESCRIPTION
`compatibility_date` is not replaced with the correct date for `wrangler.json`. This PR will fix it and update the test to check `wrangler.json` and not only `wrangler.toml`.