### PR TITLE
chore: check the latest branch of `honojs/starter`

### DIFF
--- a/.github/workflows/check-template-branch.yml
+++ b/.github/workflows/check-template-branch.yml
@@ -1,0 +1,41 @@
+name: Check Template Branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check_template_branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get create-hono version
+        id: get_version
+        run: |
+          VERSION=$(jq -r .version package.json)
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d '.' -f 1,2)
+          echo "Detected version: $VERSION"
+          echo "Branch to check: v$MAJOR_MINOR"
+          echo "branch_name=v$MAJOR_MINOR" >> "$GITHUB_ENV"
+
+      - name: Check if branch exists in template repository
+        id: check_branch
+        run: |
+          TEMPLATE_REPO="honojs/starter"
+          BRANCH_NAME=${{ env.branch_name }}
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://api.github.com/repos/$TEMPLATE_REPO/git/refs/heads/$BRANCH_NAME")
+
+          if [ "$RESPONSE" -ne 200 ]; then
+            echo "Error: Branch '$BRANCH_NAME' does not exist in $TEMPLATE_REPO"
+            exit 1
+          fi
+
+      - name: Notify branch exists
+        if: success()
+        run: |
+          echo "Branch ${{ env.branch_name }} exists in the template repository."

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,13 +17,16 @@ import {
   registerInstallationHook,
 } from './hooks/dependencies'
 
+const [major, minor] = version.split('.')
+const ref = `v${major}.${minor}`
+
 const isCurrentDirRegex = /^(\.\/|\.\\|\.)$/
 const directoryName = 'templates'
 const config = {
   directory: directoryName,
   repository: 'starter',
   user: 'honojs',
-  ref: 'main',
+  ref,
 } as const
 
 const templates = [


### PR DESCRIPTION
This PR updates the `ref` in the template configuration. The `ref` now dynamically points to the versioned branch (e.g., `v0.15`) in the `honojs/starter` repository based on the `create-hono` package version. If the corresponding branch does not exist in the `honojs/starter` repository, it will throw an error in the GitHub Actions workflow.