### PR TITLE
fix: does not work install option

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@inquirer/input": "^2.1.0",
         "@inquirer/select": "^2.2.0",
         "@types/node": "^18.11.18",
-        "@types/yargs-parser": "^21.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "esbuild": "^0.16.17",
@@ -205,8 +204,6 @@
     "@types/semver": ["@types/semver@7.5.8", "", {}, "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="],
 
     "@types/wrap-ansi": ["@types/wrap-ansi@3.0.0", "", {}, "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="],
-
-    "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@6.21.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.5.1", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/type-utils": "6.21.0", "@typescript-eslint/utils": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "graphemer": "^1.4.0", "ignore": "^5.2.4", "natural-compare": "^1.4.0", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha", "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA=="],
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,9 +59,7 @@ program
   .name('create-hono')
   .version(version)
   .arguments('[target]')
-  .addOption(
-    new Option('-i, --install', 'Install dependencies').argParser(Boolean),
-  )
+  .addOption(new Option('-i, --install', 'Install dependencies'))
   .addOption(
     new Option('-p, --pm <pm>', 'Package manager to use').choices(
       knownPackageManagerNames,
@@ -72,11 +70,7 @@ program
       templates,
     ),
   )
-  .addOption(
-    new Option('-o, --offline', 'Use offline mode')
-      .argParser(Boolean)
-      .default(false),
-  )
+  .addOption(new Option('-o, --offline', 'Use offline mode').default(false))
   .action(main)
 
 type ArgOptions = {


### PR DESCRIPTION
## Overview

I tried using the `install` option, but `npm install` and other options did not work automatically. So I fixed it so that the `install` option works.

![image](https://github.com/user-attachments/assets/8e1f842d-69a8-446f-9ceb-1ab2f11ac801)

## Chnages

- Fixed so that the value of `--install` on the command line can be obtained correctly.

## Other Changes

- I tried running `bun install` in the project setup, but a difference was found in the lock file, so I committed it.
- I also fixed the `--offline` on the command line, as it seemed to be a problem with the `--install` option.
