### PR TITLE
chore: use `bun` for building instead of `yarn`

### DIFF
--- a/src/hooks/dependencies.test.ts
+++ b/src/hooks/dependencies.test.ts
@@ -31,7 +31,7 @@ const installedPackageManagerNames = await Promise.all(
 )
 
 // Run build to have ./bin
-execaSync('yarn', 'run build'.split(' '))
+execaSync('bun', 'run build'.split(' '))
 execaSync('chmod', ['+x', './bin'])
 
 describe('dependenciesHook', async () => {


### PR DESCRIPTION
Hi @yusukebe !

This pull request includes a change to the `dependencies.test.ts` file to update the package manager used for running the build command.

* [`src/hooks/dependencies.test.ts`](diffhunk://#diff-da313a0aeea2d94d2265b6c2e28b244a106540aee8f8f97b880927937ee5d7b0L34-R34): Changed the package manager from `yarn` to `bun` for running the build command.