### PR TITLE
build: replace tsx with bun for build script

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,6 @@
         "nanospinner": "^1.2.2",
         "np": "^10.2.0",
         "prettier": "^3.5.3",
-        "tsx": "^4.19.3",
         "typescript": "^5.8.2",
         "vitest": "^3.0.9",
       },
@@ -1018,8 +1017,6 @@
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "tsx": ["tsx@4.19.3", "", { "dependencies": { "esbuild": "~0.25.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "create-hono",
   "version": "0.16.0",
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "bun ./build.ts",
     "bin": "./bin",
     "test": "vitest --run",
     "prepack": "bun run build",
@@ -41,7 +41,6 @@
     "nanospinner": "^1.2.2",
     "np": "^10.2.0",
     "prettier": "^3.5.3",
-    "tsx": "^4.19.3",
     "typescript": "^5.8.2",
     "vitest": "^3.0.9"
   }


### PR DESCRIPTION
Remove tsx dependency and update build script to use bun directly for executing build.ts. This simplifies dependencies while leveraging the bun runtime that's already a project requirement.