### PR TITLE
perf: replace execa to nano-spawn

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "commander": "^13.1.0",
         "eslint": "^9.23.0",
         "execa": "^8.0.1",
+        "nano-spawn": "^1.0.1",
         "nanospinner": "^1.2.2",
         "np": "^10.2.0",
         "picocolors": "^1.1.1",
@@ -752,6 +753,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "nano-spawn": ["nano-spawn@1.0.1", "", {}, "sha512-BfcvzBlUTxSDWfT+oH7vd6CbUV+rThLLHCIym/QO6GGLBsyVXleZs00fto2i2jzC/wPiBYk5jyOmpXWg4YopiA=="],
 
     "nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "commander": "^13.1.0",
     "eslint": "^9.23.0",
     "execa": "^8.0.1",
+    "nano-spawn": "^1.0.1",
     "nanospinner": "^1.2.2",
     "np": "^10.2.0",
     "picocolors": "^1.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "strict": true,
@@ -11,6 +11,6 @@
     ],
     "lib": [
       "esnext"
-    ],
-  },
+    ]
+  }
 }


### PR DESCRIPTION
Hi @yusukebe !

This pr replaces `execa` to [`nano-spawn`](https://www.npmjs.com/package/nano-spawn). As a result, the `bin` size is 0.5MB smaller.
I don't modify the test code because it is just works fine.
Also `nano-spawn` is esm only library and the previous tsconfig doesn't work for getting type info of `nano-spawn`, so I modified the `moduleResolution` to `bundler`