### PR TITLE
fix: Do not show the info log of `cd .`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,10 +211,12 @@ async function main(
 
   emitter.on('completed', () => {
     console.log(picocolor.green(`🎉 ${picocolor.bold('Copied project files')}`))
-    console.log(
-      picocolor.gray('Get started with:'),
-      picocolor.bold(`cd ${target}`),
-    )
+    if (target !== ".") {
+      console.log(
+        picocolor.gray('Get started with:'),
+        picocolor.bold(`cd ${target}`),
+      )
+    }
     // eslint-disable-next-line n/no-process-exit
     process.exit(0)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,7 @@ async function main(
 
   emitter.on('completed', () => {
     console.log(picocolor.green(`🎉 ${picocolor.bold('Copied project files')}`))
-    if (target !== ".") {
+    if (target !== '.') {
       console.log(
         picocolor.gray('Get started with:'),
         picocolor.bold(`cd ${target}`),

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,10 @@ async function main(
 
   emitter.on('completed', () => {
     console.log(picocolor.green(`🎉 ${picocolor.bold('Copied project files')}`))
-    if (target !== '.') {
+    const resolvedTarget = path.resolve(target);
+    const currentDir = process.cwd();
+    
+    if (resolvedTarget !== currentDir) {
       console.log(
         picocolor.gray('Get started with:'),
         picocolor.bold(`cd ${target}`),

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,9 +211,9 @@ async function main(
 
   emitter.on('completed', () => {
     console.log(picocolor.green(`🎉 ${picocolor.bold('Copied project files')}`))
-    const resolvedTarget = path.resolve(target);
-    const currentDir = process.cwd();
-    
+    const resolvedTarget = path.resolve(target)
+    const currentDir = process.cwd()
+
     if (resolvedTarget !== currentDir) {
       console.log(
         picocolor.gray('Get started with:'),


### PR DESCRIPTION
I stumbled across this when choosing the target directory as `.` (current dir) when creating a new project
![image](https://github.com/user-attachments/assets/559b2305-b04c-496e-a984-aff80abf59fb)
This PR does not show this console log when the target directory is current