### PR TITLE
feat: detect nub package manager

### DIFF
--- a/src/hooks/dependencies.ts
+++ b/src/hooks/dependencies.ts
@@ -7,7 +7,7 @@ import type { EventEmitter } from 'node:events'
 import { exit } from 'node:process'
 import { projectDependenciesHook } from '../hook'
 
-type PackageManager = 'npm' | 'bun' | 'deno' | 'pnpm' | 'yarn'
+type PackageManager = 'npm' | 'bun' | 'deno' | 'pnpm' | 'yarn' | 'nub'
 
 const knownPackageManagers: { [key: string]: string } = {
   npm: 'npm install',
@@ -15,6 +15,7 @@ const knownPackageManagers: { [key: string]: string } = {
   deno: 'deno install',
   pnpm: 'pnpm install',
   yarn: 'yarn',
+  nub: 'nub install',
 }
 
 export const knownPackageManagerNames = Object.keys(knownPackageManagers)
@@ -146,6 +147,9 @@ function getCurrentPackageManager(): PackageManager {
   }
   if (agent.startsWith('yarn')) {
     return 'yarn'
+  }
+  if (agent.startsWith('nub')) {
+    return 'nub'
   }
 
   return 'npm'


### PR DESCRIPTION
When invoked through nub, create-hono defaults to npm. It reads the invoking package manager from `npm_config_user_agent` in `getCurrentPackageManager` and falls back to npm; [nub](https://nubjs.com) advertises `nub/<version>`, so it isn't matched.

nub is a Rust CLI with a pnpm-compatible command grammar. This adds `nub` to the `PackageManager` type, the `knownPackageManagers` map (`nub install`), and the user-agent detection.
